### PR TITLE
Added Admin Decorators instead registering models separately

### DIFF
--- a/commerce/auctions/admin.py
+++ b/commerce/auctions/admin.py
@@ -2,24 +2,21 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from . models import User, Listing, Bid, Comment
 
+@admin.register(Listing)
 class ListingAdmin(admin.ModelAdmin):
     list_display = ("id", "creator", "title", "timestamp", "price", "category", "active", "winner")
 
+@admin.register(Comment)
 class CommentAdmin(admin.ModelAdmin):
     list_display = ("id", "commenter", "timestamp", "content")
 
+@admin.register(Bid)
 class BidAdmin(admin.ModelAdmin):
     list_display = ("id", "listing", "bidder", "timestamp", "bid_price")
 
+@admin.register(User)
 class CustomUserAdmin(UserAdmin):
     filter_horizontal = ("watchlist",)
     fieldsets = UserAdmin.fieldsets + (
         ("Watchlist", {'fields': ('watchlist',)}),
     )
-
-# Register your models here.
-admin.site.register(Listing, ListingAdmin)
-admin.site.register(Comment, CommentAdmin)
-admin.site.register(Bid, BidAdmin)
-admin.site.register(User, CustomUserAdmin)
-


### PR DESCRIPTION
I have added Admin Decorators instead of registering models and admin classes separately to increase code reusability.